### PR TITLE
log: avoid auto-scrolling when appending text if log not at the bottom

### DIFF
--- a/include/flan/log_widget.hpp
+++ b/include/flan/log_widget.hpp
@@ -3,6 +3,7 @@
 
 #include <flan/styled_matching_rule.hpp>
 #include <QPlainTextEdit>
+#include <QScrollBar>
 
 namespace flan
 {
@@ -32,8 +33,13 @@ public:
     QString plain_text_with_rules_applied() const;
 
 public slots:
-
     void set_rules(flan::styled_matching_rule_list_t rules);
+
+    //! Append the \a text at the end of the log.
+    //!
+    //! The current scroll position is kept if the log has some selection or if the current cursor
+    //! is not at the bottom. Otherwise, the log is scrolled to the bottom after the text is added.
+    void append_text(const QString& text);
 
 protected:
     void mouseMoveEvent(QMouseEvent* event) override;

--- a/src/log_widget.cpp
+++ b/src/log_widget.cpp
@@ -30,6 +30,33 @@ void log_widget_t::set_rules(styled_matching_rule_list_t rules)
     _highlighter->set_rules(_rules);
 }
 
+void log_widget_t::append_text(const QString& text)
+{
+    const QTextCursor old_cursor = textCursor();
+    const int old_scrollbar_value = verticalScrollBar()->value();
+    const bool is_scrolled_down = (old_scrollbar_value == verticalScrollBar()->maximum());
+
+    // Move the cursor to the end of the document and insert the text at the end.
+    moveCursor(QTextCursor::End);
+    textCursor().insertText(text);
+
+    if (old_cursor.hasSelection() || !is_scrolled_down)
+    {
+        // The user has selected some text or scrolled away from the bottom so restore the previous
+        // position so that when text is appended the user can still move to a different area of the
+        // log.
+        setTextCursor(old_cursor);
+        verticalScrollBar()->setValue(old_scrollbar_value);
+    }
+    else
+    {
+        // The user hasn't selected any text and the scrollbar is at the bottom so scroll to the
+        // bottom.
+        moveCursor(QTextCursor::End);
+        verticalScrollBar()->setValue(verticalScrollBar()->maximum());
+    }
+}
+
 void log_widget_t::mouseMoveEvent(QMouseEvent* event)
 {
     // If buttons are pressed, use the base class implementation.

--- a/src/main_widget.cpp
+++ b/src/main_widget.cpp
@@ -172,16 +172,10 @@ void main_widget_t::on_current_data_source_changed(data_source_t* data_source)
     if (_current_data_source)
     {
         connect(_current_data_source, &data_source_t::new_text, _log, [this](auto text) {
-            // QPlainTextEdit::appendPlainText() adds a new line which we don't want so we have to
-            // move the cursor to the end, insert our text and restore the previous location
-            // instead.
-            QTextCursor previous_cursor = _log->textCursor();
-            _log->moveCursor(QTextCursor::End);
-            _log->insertPlainText(text);
-            _log->setTextCursor(previous_cursor);
+            _log->append_text(text);
         });
         _log->clear();
-        _log->appendPlainText(_current_data_source->text());
+        _log->append_text(_current_data_source->text());
     }
 }
 } // namespace flan


### PR DESCRIPTION
Also don't auto scroll if the user has selected some text.

This make the log much more usable.