### PR TITLE
log: add a checkbox to show/hide log lines by default

### DIFF
--- a/include/flan/log_widget.hpp
+++ b/include/flan/log_widget.hpp
@@ -44,6 +44,12 @@ public slots:
     //! Pause appending text to the log is \a is_paused is \c true otherwise restart appending text.
     void set_paused(bool is_paused);
 
+    //! Show or hide log lines by default according to \a show_lines_by_default.
+    //!
+    //! This is the state of a line when no rules matches or the rule is not selected for keeping
+    //! or removal.
+    void set_show_lines_by_default(bool show_lines_by_default);
+
 protected:
     void mouseMoveEvent(QMouseEvent* event) override;
     QMimeData* createMimeDataFromSelection() const override;
@@ -59,5 +65,6 @@ private:
     rule_highlighter_t* _highlighter = nullptr;
     styled_matching_rule_list_t _rules;
     bool _is_paused = false;
+    bool _show_lines_by_default = true;
 };
 } // namespace flan

--- a/src/log_widget.cpp
+++ b/src/log_widget.cpp
@@ -65,6 +65,15 @@ void log_widget_t::set_paused(bool is_paused)
     _is_paused = is_paused;
 }
 
+void log_widget_t::set_show_lines_by_default(bool show_lines_by_default)
+{
+    if (_show_lines_by_default != show_lines_by_default)
+    {
+        _show_lines_by_default = show_lines_by_default;
+        apply_rules();
+    }
+}
+
 void log_widget_t::mouseMoveEvent(QMouseEvent* event)
 {
     // If buttons are pressed, use the base class implementation.
@@ -147,6 +156,9 @@ void log_widget_t::apply_rules()
 
     for (auto block = doc->begin(); block.isValid(); block = block.next())
     {
+        // Apply block default visibility.
+        block.setVisible(_show_lines_by_default);
+
         // Iterate over the rules in order and determine if the block should be visible or not.
         for (auto& styled_rule: _rules)
         {
@@ -183,15 +195,11 @@ void log_widget_t::apply_rules()
                 // A matching rule was found, so don't check remaining rules.
                 break;
             }
-            else
-            {
-                // No rule matched, so ensure the block is visible (which might not be the case if
-                // it was removed by a rule which is now not applying because unchecked or the block
-                // content changed.
-                block.setVisible(true);
-            }
         }
     }
+
+    ensureCursorVisible();
+    viewport()->update();
 }
 
 QString log_widget_t::plain_text_with_rules_applied() const

--- a/src/main_widget.cpp
+++ b/src/main_widget.cpp
@@ -73,6 +73,16 @@ main_widget_t::main_widget_t(QWidget* parent)
     auto left_widget = new QWidget;
     left_widget->setLayout(left_layout);
 
+    auto default_visibility_checkbox = new QCheckBox{tr("Default show")};
+    default_visibility_checkbox->setToolTip(tr("Show/hide log lines by default"));
+    default_visibility_checkbox->setChecked(true);
+    connect(
+        default_visibility_checkbox,
+        &QCheckBox::toggled,
+        _log,
+        &log_widget_t::set_show_lines_by_default);
+    _log->set_show_lines_by_default(default_visibility_checkbox->isChecked());
+
     auto pause_button = new QPushButton{tr("Pause")};
     pause_button->setCheckable(true);
     connect(pause_button, &QPushButton::toggled, _log, &log_widget_t::set_paused);
@@ -83,6 +93,7 @@ main_widget_t::main_widget_t(QWidget* parent)
     auto bottom_layout = new QHBoxLayout;
     bottom_layout->setContentsMargins(0, 0, 0, 0);
     bottom_layout->addWidget(_data_source, 1);
+    bottom_layout->addWidget(default_visibility_checkbox);
     bottom_layout->addWidget(pause_button);
     bottom_layout->addWidget(clear_button);
 


### PR DESCRIPTION
This avoids the need of having a "Match anything" (.*) rule at the end of the rule tree in case one want to always hide everything and selectively select rules to show.